### PR TITLE
Add support for CentOS/RHEL

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
     version={{ watchman_version }}
   tags: watchman
 
-- name: Install Watchman build dependencies
+- name: Install Watchman build dependencies (Debian/Ubuntu)
   apt: >
     pkg={{item}}
     state=installed
@@ -29,6 +29,16 @@
   become: yes
   become_method: sudo
   tags: watchman
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+
+- name: Install Watchman build dependencies (RHEL/CentOS)
+  yum: >
+    pkg="@Development tools"
+    state=present
+  become: yes
+  become_method: sudo
+  tags: watchman
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
 
 - name: Autogen Watchman
   command: >
@@ -55,4 +65,3 @@
   become: yes
   become_method: sudo
   tags: watchman
-


### PR DESCRIPTION
As title says, Add support for RHEL/CentOS by adding the proper dependency groupinstall.

I tried to follow the existing style of the package, let me know if any changes are required.